### PR TITLE
Change budget alert index to `0`

### DIFF
--- a/budget-alert.tf
+++ b/budget-alert.tf
@@ -14,7 +14,7 @@ resource "azurerm_consumption_budget_resource_group" "grafana-budget-alert" {
     dimension {
       name = "ResourceId"
       values = [
-        azurerm_dashboard_grafana.dashboard-grafana[count.index].id,
+        azurerm_dashboard_grafana.dashboard-grafana[0].id,
       ]
     }
   }


### PR DESCRIPTION
### Change description ###
As requested from Daniel Wilson - change should be:
From `azurerm_dashboard_grafana.dashboard-grafana[count.index].id,`
To `azurerm_dashboard_grafana.dashboard-grafana[0].id,`

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [-] README and other documentation has been updated / added (if needed)
- [-] tests have been updated / new tests has been added (if needed)
- [-] Does this PR introduce a breaking change
